### PR TITLE
Font generator

### DIFF
--- a/src/app/scripts/compilers/FontGenerator.js
+++ b/src/app/scripts/compilers/FontGenerator.js
@@ -1,0 +1,165 @@
+/**
+ * FontGenerator
+ */
+
+'use strict';
+
+var FileManager = global.getFileManager(),
+    util = require('../util'),
+    Compiler    = require(FileManager.appScriptsDir + '/Compiler.js'),
+    path = require('path');
+
+/**
+ * FontGenerator
+ * @param {object} config compiler config
+ */
+function FontGenerator(config) {
+    Compiler.call(this, config);
+}
+require('util').inherits(FontGenerator, Compiler);
+
+module.exports = FontGenerator;
+
+/**
+ * font generator utils
+ */
+FontGenerator.prototype.utils = {
+    getFileExtension: function(font){
+        var match = font.match(/\.([^.]+)$/);
+        if (match && match[1])
+            return match[1];
+    }
+}
+
+/**
+ * compile file
+ * @param  {Object} file    compile file object
+ * @param  {Object} emitter  compile event emitter
+ */
+FontGenerator.prototype.compile = function (file, emitter) {
+    var self = this,
+        globalSettings = this.getGlobalSettings(),
+        platform = util.getPlatformName();
+
+    file.supported = ['ttf', 'otf', 'svg', 'woff', 'eot'];
+    var fontforgeConvert = self.compileByFontforge(file);
+
+    if (platform === 'windows' && !fontforgeConvert ){
+        emitter.emit('fail');
+        emitter.emit('always');
+        return self.throwError('please configure fontforge path!', file.src);
+    };
+
+    self.execProcess(fontforgeConvert, function(err, stdout, stderr) {
+        if (err) {
+            emitter.emit('fail');
+            emitter.emit('always');
+            return self.throwError(stderr.toString('utf8'), file.src);
+        }
+        self.compileEotFont(file, emitter);
+    });
+}
+
+/**
+ * compile font by fontforge
+ * supported: ttf, otf, svg, woff
+ * @param  {Object} file    compile file object
+ */
+FontGenerator.prototype.compileByFontforge = function (file) {
+    var self = this,
+        globalSettings = this.getGlobalSettings(),
+        platform = util.getPlatformName(),
+        escapestr = platform === 'windows' ? '\"' : '\'',
+        executable = globalSettings.advanced.commandPath ? '"' + globalSettings.advanced.commandPath + '"' : 'fontforge',
+        ext = self.utils.getFileExtension(file.name.toString()),
+        convertString = ['Open($1)'];
+
+    file.outputDir = file.output;
+
+    // windows: fontforge.bat
+    if (platform === 'windows' && !globalSettings.advanced.commandPath) {
+        return false;
+    };
+    if (platform !== 'windows') {
+        executable += ' -lang=ff';
+    };
+    executable += ' -c';
+
+    file.supported.pop(); // delete eot
+    file.supported.splice(file.supported.indexOf(ext), 1); // delete ext
+    file.supported.forEach(function(item) {
+        if (platform === 'windows') {
+            convertString.push('Generate($2+\'.' + item + '\')');
+            file.outputDir = path.join(file.output, file.name).slice(0,-(ext.length + 1));
+        } else {
+            convertString.push('Generate($2 + $1:t:r + ".' + item + '")');
+            file.outputDir = path.join(file.output, file.name).slice(0,-file.name.length);
+        }
+    });
+
+    // if outputDir has changed, generate source font
+    if (file.outputDir != file.src.slice(0, -file.name.length)) {
+        platform !== 'windows' ? convertString.push('Generate($2 + $1:t:r + ".'+ ext +'")') : convertString.push('Generate($2+\'.'+ ext +'\')');
+    }
+
+    convertString =  escapestr + convertString.join(';') + escapestr;
+   
+    var args = [file.src, file.outputDir].join(' ');
+    return [executable, convertString, args].join(' ');
+}
+
+/**
+ * compile eot font from ttf
+ * @param  {Object} file    compile file object
+ * @param  {Object} emitter  compile event emitter
+ */
+FontGenerator.prototype.compileEotFont = function(file, emitter) {
+    var self = this,
+        fs = require('fs'),
+        ttf2eot = require('ttf2eot'),
+        ext = self.utils.getFileExtension(file.name.toString()),
+        input, ttf, eot, ext, source;
+
+    var triggerError = function (message) {
+        emitter.emit('fail');
+        emitter.emit('always');
+        self.throwError(message, file.src);
+    };
+    var triggerSuccess = function () {
+        emitter.emit('done');
+        emitter.emit('always');
+    }
+
+    try {
+        ext !== 'ttf' ? source = file.src.slice(0, -ext.length) + 'ttf' : source = file.src;
+        input = fs.readFileSync(source);
+    } catch(e) {
+        return triggerError(e);
+    }
+
+    try {
+        ttf = new Uint8Array(input);
+        eot = new Buffer(ttf2eot(ttf).buffer);
+    } catch (e) {
+        return triggerError(e);
+    }
+
+    fs.writeFile(path.join(file.output, file.name.slice(0, -ext.length) + 'eot'), eot, function(err) {
+        if (err) {
+            return triggerError(err);
+        }
+        triggerSuccess();
+    });
+}
+
+/**
+ * exec for fontforge
+ * @param  {String} command    command string
+ * @param {Function} callback   callback function
+ */
+FontGenerator.prototype.execProcess = function(command, callback){
+    var exec = require('child_process').exec;
+    var proc = exec(command, { timeout: 5000, maxBuffer: 2000*1024 }, function(err, stdout, stderr) {
+        callback(err, stdout, stderr);
+    });
+}

--- a/src/app/scripts/compilers/package.json
+++ b/src/app/scripts/compilers/package.json
@@ -423,6 +423,64 @@
 		],
 
 		"libraries": ["clean-css@1.0.12"]
+	},
+
+
+	// Font Generator
+	{
+		"name": "font",
+
+		"display": "FontGenerator",
+
+		"version": "1.0.0",
+
+		"koalaVersion": ">=2.3.0",
+
+		"main": "FontGenerator.js",
+
+		"fileTypes": [{
+			"extension": "ttf", 
+			"outputType": "dir",
+			"output": "",
+			"icon": "../../assets/img/filetypes/ttf.png",
+			"category": "font",
+			"autocompile": false
+		},{
+			"extension": "otf", 
+			"outputType": "dir",
+			"output": "",
+			"icon": "../../assets/img/filetypes/otf.png",
+			"category": "font",
+			"autocompile": false
+		},{
+			"extension": "svg", 
+			"outputType": "dir",
+			"output": "",
+			"icon": "../../assets/img/filetypes/svg.png",
+			"category": "font",
+			"autocompile": false
+		},{
+			"extension": "woff",
+			"outputType": "dir", 
+			"output": "",
+			"icon": "../../assets/img/filetypes/woff.png",
+			"category": "font",
+			"autocompile": false
+		}],
+
+		"options": [],
+
+		"advanced": [{
+			"type": "text",
+			"name": "commandPath",
+			"display": "Use the Fontforge executable at this path",
+			"default": "",
+			"placeholder": "Default: fontforge"
+		}],
+
+		"projectSettings": "",
+
+		"libraries": ["ttf2eot@1.3.0"]
 	}
 
 ]

--- a/src/app/scripts/jadeManager.js
+++ b/src/app/scripts/jadeManager.js
@@ -56,6 +56,11 @@ exports.renderFiles  = function (data) {
         item.shortOutput = path.relative(parentSrc, item.output);
         
         ext = path.extname(item.src).substr(1);
+
+        if (item.outputType === 'dir') {
+            item.shortOutput = item.output;
+        };
+
         item.icon = fileTypesManager.getFileTypeByExt(ext).icon;
 
         if (item.compile) {

--- a/src/app/scripts/pages/main/options.js
+++ b/src/app/scripts/pages/main/options.js
@@ -72,6 +72,7 @@ function setMultipleOutput (selectedItems, pid, outputDir) {
 
     selectedItems.each(function () {
         var src        = $(this).data('src'),
+            outputType = $(this).data('output'),
             targetFile = projectsDb[pid].files[src],
             oldOutput  = targetFile.output,
             name       = path.basename(oldOutput),
@@ -82,6 +83,9 @@ function setMultipleOutput (selectedItems, pid, outputDir) {
             name = name.replace('.min', '')
         }
 
+        if (outputType === 'dir') {
+            name = '';
+        }
         newOutput  = path.join(outputDir, name);
         targetFile.output = newOutput;
 
@@ -90,7 +94,7 @@ function setMultipleOutput (selectedItems, pid, outputDir) {
             src: src
         })
 
-        var shortOutput = path.relative(activeProject.src, newOutput);
+        var shortOutput = outputType === 'dir' ? newOutput : path.relative(activeProject.src, newOutput);
         $(this).find('.output span').text(shortOutput);
     })
 
@@ -145,8 +149,10 @@ $('#filelist').on('setOutputPath', '.file_item', function () {
 });
 $('#filelist').on('click', '.changeOutput', function () {
     var selectItem  = $(this).closest('.file_item');
-
-    $('#ipt_fileOutput')
+    var output = '#ipt_fileOutput';
+    if($(this).parents('li').data('output') === 'dir')
+        output += 'Dir';
+    $(output)
         .attr('nwWorkingDir', path.dirname(selectItem.data('src')))
         .trigger('click');
 

--- a/src/app/scripts/projectManager.js
+++ b/src/app/scripts/projectManager.js
@@ -504,6 +504,7 @@ function creatFileObject(fileSrc, config) {
         compiler: compilerName,                         //Compiler Name
         name: path.basename(fileSrc),                   //Name
         src: fileSrc,                                   //Path
+        outputType: fileType.outputType,
         output: output,                                 //Output Path
         compile: fileType.autocompile,                  //whether to auto compile
         watch: fileType.watch,                          //whether to watch this file
@@ -550,6 +551,10 @@ function getCompileOutput(fileSrc, mappings) {
     if (fileSrc === output) {
         output = fileSrc.slice(0, -extension.length) + 'min.' + fileType.output;
     }
+
+    if (fileType.outputType === 'dir') {
+        output = fileSrc.slice(0, -(path.basename(fileSrc).length + 1));
+    };
 
     return output;
 }

--- a/src/app/views/template/main.html
+++ b/src/app/views/template/main.html
@@ -46,6 +46,7 @@
 			<li data-type="template">Tmpl</li>
 			<li data-type="javascript">JS</li>
 			<li data-type="css">CSS</li>
+			<li data-type="font">Font</li>
 			<!-- <li data-type="image">Images</li> -->
 		</ul>
 	</footer>

--- a/src/app/views/template/main/files.jade
+++ b/src/app/views/template/main/files.jade
@@ -1,6 +1,6 @@
 each item in files
 	classList = 'type_' + item.category + (item.compile ? '' : ' disable') + (item.watch ? ' watch' : ' nowatch')
-	li.file_item(class=classList, data-src=item.src, data-type=item.type, data-pid=item.pid, data-id=item.id, id=item.id)
+	li.file_item(class=classList, data-src=item.src, data-type=item.type, data-pid=item.pid, data-id=item.id, data-output=item.outputType, id=item.id)
 		img.icon(src=item.icon)
 		h3.name= item.shortSrc
 		p.output

--- a/src/node_modules/README.md
+++ b/src/node_modules/README.md
@@ -5,5 +5,6 @@
 * less
 * uglify-js
 * autoprefixer
+* ttf2eot
 
 [How to Install a package?](https://npmjs.org/doc/cli/npm-install.html)


### PR DESCRIPTION
Add webfont generator for koala, supported font type: ttf, otf, svg, woff, eot.
Node module ttf2eot [1] and fontforge [2] should be installed.
In Windows, it should configure fontforge path first. 
Not tested in Mac OS X.
[1] https://www.npmjs.org/package/ttf2eot
[2] http://fontforge.org
