### PR TITLE
Fix backslashes in map source paths on Windows

### DIFF
--- a/src/app/scripts/compilers/LessCompiler.js
+++ b/src/app/scripts/compilers/LessCompiler.js
@@ -460,7 +460,7 @@ LessCompiler.prototype.replaceSourcesPath = function (options) {
         
         mapObj.sources = mapObj.sources.map(function (item) {
             if (item.indexOf(':') > -1 || item.indexOf('/') === 0) {
-                return path.relative(sourceRoot, item);    
+                return path.relative(sourceRoot, item).replace(/\\/g, '/');    
             } else {
                 return item;
             }


### PR DESCRIPTION
Map source paths are relative URLs, not local file paths, so forward slashes should always be used.