### PR TITLE
Auto prefixer config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src/node_modules/dustjs-linkedin
 src/node_modules/less
 src/node_modules/uglify-js
 src/node_modules/autoprefixer
+src/rubygems
 src/rubygems/bin
 src/rubygems/gems
 src/rubygems/specifications

--- a/src/app/scripts/appConfigManager.js
+++ b/src/app/scripts/appConfigManager.js
@@ -105,7 +105,7 @@ function loadLanguages () {
  */
 exports.initCompilerOptions = function (options) {
     var config = getUserConfig(), syncAble;
-    
+
     for (var k in options) {
         if (!config.compilers[k]) {
             config.compilers[k] = options[k];

--- a/src/app/scripts/compilers/CssCompiler.js
+++ b/src/app/scripts/compilers/CssCompiler.js
@@ -6,6 +6,7 @@
 var fs          = require('fs-extra'),
     path        = require('path'),
     FileManager = global.getFileManager(),
+    common      = require('./common.js'),
     Compiler    = require(FileManager.appScriptsDir + '/Compiler.js');
 
 /**
@@ -39,7 +40,7 @@ CssCompiler.prototype.compile = function(file, emitter) {
         visited: []
     };
 
-    if (file.settings.combineImport) { 
+    if (file.settings.combineImport) {
         options.processImport = true;
     }
 
@@ -47,7 +48,11 @@ CssCompiler.prototype.compile = function(file, emitter) {
     // global.debug(options.visited)
 
     if (file.settings.autoprefix) {
-        resultCss = require('autoprefixer').process(resultCss).css;
+        var autoprefixer = require('autoprefixer'),
+                autoprefixConfig = file.settings.autoprefixConfig || common.autoprefixerDefault,
+                getAutoprefixConfig = common.getAutoprefixConfig(_this, autoprefixConfig);
+
+        resultCss = autoprefixer(getAutoprefixConfig).process(resultCss).css;
     }
 
     // convert background image to base64 & append timestamp
@@ -72,7 +77,7 @@ CssCompiler.prototype.compile = function(file, emitter) {
  * @param  {String}     css         css code
  * @param  {String}     rootPath    the css file path
  * @param  {Boolean}    timestamp   whether append timestamp
- * @return {String}                 the converted css code 
+ * @return {String}                 the converted css code
  */
 function convertImageUrl (css, rootPath, timestamp) {
     css = css.replace(/background.+?url.?\(.+?\)/gi, function (matchStr) {
@@ -118,7 +123,7 @@ function img2base64(url, rootPath){
 
     var file = path.join(rootPath, url);
     try {
-        var imageBuf = fs.readFileSync(file); 
+        var imageBuf = fs.readFileSync(file);
         return prefix + imageBuf.toString("base64");
     } catch(err) {
         // the file doesn't exist

--- a/src/app/scripts/compilers/CssCompiler.js
+++ b/src/app/scripts/compilers/CssCompiler.js
@@ -49,8 +49,8 @@ CssCompiler.prototype.compile = function(file, emitter) {
 
     if (file.settings.autoprefix) {
         var autoprefixer = require('autoprefixer'),
-                autoprefixConfig = file.settings.autoprefixConfig || common.autoprefixerDefault,
-                getAutoprefixConfig = common.getAutoprefixConfig(_this, autoprefixConfig);
+            autoprefixConfig = file.settings.autoprefixConfig || common.autoprefixerDefault,
+            getAutoprefixConfig = common.getAutoprefixConfig(_this, autoprefixConfig);
 
         resultCss = autoprefixer(getAutoprefixConfig).process(resultCss).css;
     }

--- a/src/app/scripts/compilers/LessCompiler.js
+++ b/src/app/scripts/compilers/LessCompiler.js
@@ -29,12 +29,14 @@ module.exports = LessCompiler;
 LessCompiler.prototype.compile = function (file, emitter) {
     //compile file by use system command
     var settings = this.getGlobalSettings();
+
     if (settings.advanced.useCommand) {
         this.compileWithCommand(file, emitter);
     } else {
         this.compileWithLib(file, emitter);
     }
-}
+};
+
 /**
  * compile less file
  * @param  {Object} file    compile file object
@@ -163,7 +165,7 @@ LessCompiler.prototype.compileWithLib = function (file, emitter) {
         options.sourceMapFullFilename =  output + '.map';
     }
     var writeSourceMap = function (sourceMapOutput) {
-        var filename =options.sourceMapFullFilename;
+        var filename = options.sourceMapFullFilename;
         sourceMapOutput = self.replaceSourcesPath({
             inputFilePath: filePath,
             outputFilePath: output,
@@ -176,8 +178,8 @@ LessCompiler.prototype.compileWithLib = function (file, emitter) {
         emitter.emit('fail');
         emitter.emit('always');
         self.throwError(parseError(error), filePath);
-    }
-    
+    };
+
     var saveCss = function (css) {
         // remove local file path prefix
         if (settings.lineComments || settings.debugInfo) {
@@ -188,13 +190,20 @@ LessCompiler.prototype.compileWithLib = function (file, emitter) {
 
         // auto add css prefix
         if (settings.autoprefix) {
-            css = require('autoprefixer').process(css).css;
+
+            var autoprefixer = require('autoprefixer'),
+                autoprefixConfig = settings.autoprefixConfig || common.autoprefixerDefault,
+                getAutoprefixConfig = common.getAutoprefixConfig(self, autoprefixConfig);
+
+            // Config is passed through from common.js
+            css = autoprefixer(getAutoprefixConfig).process(css).css;
+
             if (settings.sourceMap) {
-                css = css + '\n/*# sourceMappingURL=' + path.basename(output) + '.map */'
+                css = css + '\n/*# sourceMappingURL=' + path.basename(output) + '.map */';
             }
         }
 
-        //write css code into output
+        // write css code into output
         fs.writeFile(output, css, 'utf8', function (wErr) {
             if (wErr) {
                 triggerError(wErr);
@@ -202,13 +211,13 @@ LessCompiler.prototype.compileWithLib = function (file, emitter) {
                 emitter.emit('done');
                 emitter.emit('always');
 
-                //add watch import file
+                // add watch import file
                 common.watchImports('less', filePath);
             }
         });
-    }
-    
-    //read code content
+    };
+
+    // read code content
     fs.readFile(filePath, 'utf8', function (rErr, code) {
         if (rErr) {
             triggerError(rErr);
@@ -266,7 +275,6 @@ LessCompiler.prototype.compileWithCommand = function (file, emitter) {
         '"' + filePath + '"',
         '"' + output + '"'
         ];
-
     //custom options
     var customOptions = pcfg.customOptions;
     if (Array.isArray(customOptions)) {
@@ -279,7 +287,7 @@ LessCompiler.prototype.compileWithCommand = function (file, emitter) {
     // include paths
     // --include-path=PATHS. Set include paths. Separated by `:'. Use `;' on Windows
     var paths = self.getAppConfig().includePaths;
-    if (Array.isArray(pcfg.includePaths) && pcfg.includePaths.length) { 
+    if (Array.isArray(pcfg.includePaths) && pcfg.includePaths.length) {
         paths = paths.concat(pcfg.includePaths);
     }
     if (paths.length) {
@@ -343,21 +351,21 @@ LessCompiler.prototype.compileWithCommand = function (file, emitter) {
         }
     }
     //==== /for lessphp ====
-    
+
     var execOpts = {
         timeout: 5000
     };
-    
+
     // fix #129 env: node: No such file or directory
     if (process.platform === 'darwin') {
         execOpts.env = {
             PATH: "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin/"
-        }
+        };
     }
 
     var reWriteSourceMap = function () {
         var sourceMapPath = output + '.map';
-        
+
         if (!fs.existsSync(sourceMapPath)) {
             return false;
         }
@@ -457,10 +465,10 @@ LessCompiler.prototype.replaceSourcesPath = function (options) {
     try {
         var mapObj = JSON.parse(options.sourceMapOutput),
             sourceRoot = path.dirname(options.inputFilePath);
-        
+
         mapObj.sources = mapObj.sources.map(function (item) {
             if (item.indexOf(':') > -1 || item.indexOf('/') === 0) {
-                return path.relative(sourceRoot, item);    
+                return path.relative(sourceRoot, item);
             } else {
                 return item;
             }
@@ -468,9 +476,9 @@ LessCompiler.prototype.replaceSourcesPath = function (options) {
 
         mapObj.sourceRoot = path.relative(path.dirname(options.outputFilePath), sourceRoot);
         mapObj.file = path.basename(mapObj.file);
-        
+
         return JSON.stringify(mapObj);
     } catch (e) {
         return options.sourceMapOutput;
     }
-}
+};

--- a/src/app/scripts/compilers/SassCompiler.js
+++ b/src/app/scripts/compilers/SassCompiler.js
@@ -154,15 +154,18 @@ SassCompiler.prototype.sassCompile = function (file, emitter) {
         } else {
             emitter.emit('done');
 
-            //watch import file
+            // watch import file
             common.watchImports('sass', filePath);
 
             // auto add css prefix
             if (settings.autoprefix) {
-                common.autoprefix(file);
+                var autoprefixConfig = settings.autoprefixConfig || common.autoprefixerDefault,
+                    getAutoprefixConfig = common.getAutoprefixConfig(self, autoprefixConfig);
+
+                common.autoprefix(file, getAutoprefixConfig);
             }
         }
-            
+
         // do awayls
         emitter.emit('always');
     });
@@ -223,7 +226,7 @@ SassCompiler.prototype.compassCompile = function (file, emitter) {
     // if (settings.sourceMap) {
     //     argv.push('--sourcemap');
     // }
-    
+
     var command = self.getCompassCmd(projectConfig.useSystemCommand) + ' ' + argv.join(' ');
 
     exec(command, {cwd: projectDir, timeout: 5000, maxBuffer: 2000*1024}, function (error, stdout, stderr) {

--- a/src/app/scripts/compilers/SassCompiler.js
+++ b/src/app/scripts/compilers/SassCompiler.js
@@ -161,7 +161,6 @@ SassCompiler.prototype.sassCompile = function (file, emitter) {
             if (settings.autoprefix) {
                 var autoprefixConfig = settings.autoprefixConfig || common.autoprefixerDefault,
                     getAutoprefixConfig = common.getAutoprefixConfig(self, autoprefixConfig);
-
                 common.autoprefix(file, getAutoprefixConfig);
             }
         }

--- a/src/app/scripts/compilers/common.js
+++ b/src/app/scripts/compilers/common.js
@@ -4,6 +4,8 @@
 
 var fs = require('fs'),
     path = require('path'),
+    projectSettings = require('../projectSettings.js'),
+    $ = global.jQuery,
     fileWatcher = require('../fileWatcher.js');
 
 /**
@@ -104,6 +106,21 @@ exports.autoprefixerDefault = ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 
 exports.getAutoprefixConfig = function(scope, autoprefixConfig) {
     var customBrowsers = {};
     customBrowsers.browsers = [];
+
+    var target = $('#projects').find('.active').data('src'),
+        settingsPath = projectSettings.getConfigFilePath(scope.display.toLowerCase(), target);
+
+    if (fs.existsSync(settingsPath)) {
+        var settingsJson = projectSettings.parseKoalaConfig(settingsPath);
+
+        if (settingsJson.options && settingsJson.options.autoprefixConfig && settingsJson.options.autoprefixConfig.browsers) {
+            customBrowsers.browsers = settingsJson.options.autoprefixConfig.browsers;
+
+            if (customBrowsers.browsers !== undefined) {
+                return customBrowsers;
+            }
+        }
+    }
 
     if (typeof autoprefixConfig !== 'object') {
         // If a string is passed through, remove all commas and send to array

--- a/src/app/scripts/compilers/common.js
+++ b/src/app/scripts/compilers/common.js
@@ -29,7 +29,7 @@ function getOrWatchStyleImports (lang, srcFile, deepWatch, deepLevel) {
         item = matchs[1];
 
         if (!item) return false;
-        
+
         if (/.less|.sass|.scss/.test(path.extname(item)) || path.extname(item) === '') {
             result.push(item);
         }
@@ -39,7 +39,7 @@ function getOrWatchStyleImports (lang, srcFile, deepWatch, deepLevel) {
     var dirname = path.dirname(srcFile),
         extname = path.extname(srcFile),
         fullPathImports = [];
-    
+
     result.forEach(function (item) {
         if (path.extname(item) !== extname) {
             item += extname;
@@ -83,16 +83,40 @@ exports.watchImports = function (lang, srcFile) {
  * auto add vendor prefixes
  * @param  {object} file object
  */
-exports.autoprefix = function (file) {
+exports.autoprefix = function (file, config) {
     var cssFile = file.output,
         css = fs.readFileSync(cssFile),
         autoprefixer = require('autoprefixer');
 
-    css = autoprefixer.process(css).css;
+    config = config || exports.autoprefixerDefault;
+
+    css = autoprefixer(config).process(css).css;
 
     if (file.settings.sourceMap) {
-        css = css + '\n/*# sourceMappingURL=' + path.basename(cssFile) + '.map */'
+        css = css + '\n/*# sourceMappingURL=' + path.basename(cssFile) + '.map */';
     }
 
     fs.writeFileSync(cssFile, css);
-}
+};
+
+exports.autoprefixerDefault = ['> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1'];
+
+exports.getAutoprefixConfig = function(scope, autoprefixConfig) {
+    var customBrowsers = {};
+    customBrowsers.browsers = [];
+
+    if (typeof autoprefixConfig !== 'object') {
+        // If a string is passed through, remove all commas and send to array
+        autoprefixConfig = autoprefixConfig.split(',');
+    }
+
+    customBrowsers.browsers = autoprefixConfig;
+
+    for (var i = 0; i < customBrowsers.browsers.length; i++) {
+        // Here we remove all trailing space + remove all quotes so that it can be correctly parsed
+        customBrowsers.browsers[i] = customBrowsers.browsers[i].trim().replace(/['"]+/g, '');
+    }
+
+    // Return the browsers object with the browser array for Autoprefix to consume
+    return customBrowsers;
+};

--- a/src/app/scripts/compilers/package.json
+++ b/src/app/scripts/compilers/package.json
@@ -17,7 +17,7 @@
 		],
 
 		"fileTypes": [{
-			"extension": "less", 
+			"extension": "less",
 			"output": "css",
 			"icon": "../../assets/img/filetypes/less.png",
 			"category": "style"
@@ -60,6 +60,14 @@
 				"name": "autoprefix",
 				"display": "Autoprefix",
 				"default": false
+			},
+			{
+				"type": "text",
+				"name": "autoprefixConfig",
+				"display": "Autoprefix Config",
+				"default": "",
+				"placeholder": "> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1",
+				"depend": "autoprefix"
 			},
 			{
 				"type": "droplist",
@@ -117,13 +125,13 @@
 
 		"fileTypes": [
 			{
-				"extension": "sass", 
+				"extension": "sass",
 				"output": "css",
 				"icon": "../../assets/img/filetypes/sass.png",
 				"category": "style"
 			},
 			{
-				"extension": "scss", 
+				"extension": "scss",
 				"output": "css",
 				"icon": "../../assets/img/filetypes/scss.png",
 				"category": "style"
@@ -166,6 +174,14 @@
 				"name": "autoprefix",
 				"display": "Autoprefix",
 				"default": false
+			},
+			{
+				"type": "text",
+				"name": "autoprefixConfig",
+				"display": "Autoprefix Config",
+				"default": "",
+				"placeholder": "> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1",
+				"depend": "autoprefix"
 			},
 			{
 				"type": "droplist",
@@ -269,7 +285,7 @@
 		"main": "CoffeeScriptCompiler.js",
 
 		"fileTypes": [{
-			"extension": "coffee", 
+			"extension": "coffee",
 			"output": "js",
 			"icon": "../../assets/img/filetypes/coffee.png",
 			"category": "script"
@@ -320,7 +336,7 @@
 	},
 	{
 		"name": "uglifyjs",
-		
+
 		"display": "JavaScript",
 
 		"version": "1.0.1",
@@ -383,7 +399,7 @@
 		},
 
 		"fileTypes": [{
-			"extension": "css", 
+			"extension": "css",
 			"output": "css",
 			"icon": "../../assets/img/filetypes/css.png",
 			"category": "css",
@@ -409,6 +425,14 @@
 				"name": "autoprefix",
 				"display": "Autoprefix",
 				"default": false
+			},
+			{
+				"type": "text",
+				"name": "autoprefixConfig",
+				"display": "Autoprefix Config",
+				"default": "",
+				"placeholder": "> 1%', 'last 2 versions', 'Firefox ESR', 'Opera 12.1",
+				"depend": "autoprefix"
 			},
 			{
 				"type": "droplist",

--- a/src/app/scripts/projectManager.js
+++ b/src/app/scripts/projectManager.js
@@ -209,6 +209,7 @@ function loadExistsProjectConfig (src) {
     }
 
     settingsPath = path.join(src, 'koala-config.json');
+
     if (fs.existsSync(settingsPath)) {
         return projectSettings.parseKoalaConfig(settingsPath);
     }
@@ -442,7 +443,7 @@ function isIgnoreDir (dir, ignores) {
             return dir.indexOf(item) > -1;
         }
         return path.basename(dir) === item;
-    }); 
+    });
 }
 
 /**
@@ -466,7 +467,7 @@ function isValidFile(filePath) {
     var inIgnores = ignores.some(function (item) {
         if (item.indexOf('*') === 0) {
             return name.indexOf(item.substr(1)) > -1;
-        } 
+        }
     });
 
     if (inIgnores) return false;
@@ -541,7 +542,7 @@ function getCompileOutput(fileSrc, mappings) {
 
         if (inMappings) return output;
     }
-    
+
     // for default
     var sep = path.sep,
         typeMent = sep + fileType.compiler + sep,

--- a/src/app/settings/koala-config-of-less.json
+++ b/src/app/settings/koala-config-of-less.json
@@ -32,7 +32,10 @@
 		"sourceMap": false,
 
         // auto add vendor prefixes to rules
-        "autoprefix": false
+        "autoprefix": true,
+        "autoprefixConfig" : {
+        	"browsers": ""
+        }
 	},
 
 	// Other compile options.

--- a/src/app/settings/koala-config-of-less.json
+++ b/src/app/settings/koala-config-of-less.json
@@ -2,7 +2,7 @@
 {
 	// The mappings of source directory and output directory
 	"mappings": [
-		// {	
+		// {
 		// 	"src": "path/to/source",
 		// 	"dest": "path/to/output"
 		// }
@@ -34,7 +34,7 @@
         // auto add vendor prefixes to rules
         "autoprefix": true,
         "autoprefixConfig" : {
-        	"browsers": ""
+        	"browsers": ["> 1%", "last 2 versions", "Firefox ESR", "Opera 12.1"]
         }
 	},
 

--- a/src/app/settings/koala-config-of-sass.json
+++ b/src/app/settings/koala-config-of-sass.json
@@ -2,7 +2,7 @@
 {
 	// The mappings of source directory and output directory
 	"mappings": [
-		// {	
+		// {
 		// 	"src": "path/to/source",
 		// 	"dest": "path/to/output"
 		// }
@@ -31,7 +31,10 @@
 		"unixNewlines": false,
 
         // auto add vendor prefixes to rules
-        "autoprefix": false
+        "autoprefix": false,
+        "autoprefixConfig" : {
+        	"browsers": ["> 1%", "last 2 versions", "Firefox ESR", "Opera 12.1"]
+        }
 	},
 
 	// Other compile options, use the full name of options.


### PR DESCRIPTION
### Feature - Allow Users to provide a browser config for Autoprefix

- Allow users to pass in a configuration string for auto prefixer (will add to wiki if accepted)

- An input will be editable if AutoPrefix is enabled on Sass and Less from within the settings dialog, a user can edit comma separated values that are accepted by autoprefixer to use a custom configuration. 

- User error (i.e quotations) will be removed and stripped.

- If no config is provided the default will be used.

- Allow custom `koala-config.json` project files to be used and take precedence over GUI settings

- Update default `koala-config.json` files for LESS and SASS for project templates

- Minor tidy up with whitespace and missing semicolons

- Add Ruby Gems to gitignore

@oklai I have a question involving the user config json and the priority - Should the users project settings json config take priority over the settings from the GUI? or the other way around? Currently this is set up so that if a project config file exists, that should be used over the settings in the GUI, can easily be swapped around but this looks to be the priority for all other settings (i.e ignores). Thanks!