### PR TITLE
Fix the empty-error issues & fix not overwriting CSS files issues

### DIFF
--- a/src/app/scripts/compilers/SassCompiler.js
+++ b/src/app/scripts/compilers/SassCompiler.js
@@ -231,7 +231,7 @@ SassCompiler.prototype.compassCompile = function (file, emitter) {
     // if (settings.sourceMap) {
     //     argv.push('--sourcemap');
     // }
-
+    argv.push('--force');
     var command = self.getCompassCmd(projectConfig.useSystemCommand) + ' ' + argv.join(' ');
 
     exec(command, {cwd: projectDir, timeout: 60000, maxBuffer: 10000*1024}, function (error, stdout, stderr) {


### PR DESCRIPTION
Fix the empty-error issues
Fix the issues of not overwriting CSS files when compiling manually in compass mode